### PR TITLE
When there are no posts to show, there is no $post, thus no post-type…

### DIFF
--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -555,11 +555,11 @@ class Admin {
 		global $abet_template_post;
 
 		if ( is_post_type_archive() ) {
-			global $post;
+			global $wp_query;
 
 			$post_type  = 'pt-arch-templates';
 			$meta_key   = '_template_for_posttype_archive';
-			$meta_value = get_post_type( $post );
+			$meta_value = $wp_query->get( 'post_type' );
 			$templates  = [
 				'abet-' . $meta_value . '-archive.php',
 				'abet-posttype-archive.php',


### PR DESCRIPTION
… to get for said post. Use wp_query to get the post-type.