### PR TITLE
Inherit the target post type's allowed blocks in the template editor

### DIFF
--- a/src/admin/class-admin.php
+++ b/src/admin/class-admin.php
@@ -62,6 +62,7 @@ class Admin {
 		add_action( 'admin_enqueue_scripts', [ 'Acato\Block_Editor_Templates\Admin\Admin', 'enqueue_admin_assets' ] );
 		add_action( 'admin_menu', [ 'Acato\Block_Editor_Templates\Admin\Admin', 'admin_menu' ] );
 		add_filter( 'display_post_states', [ 'Acato\Block_Editor_Templates\Admin\Admin', 'add_display_post_states' ], 10, 2 );
+		add_filter( 'allowed_block_types_all', [ 'Acato\Block_Editor_Templates\Admin\Admin', 'inherit_allowed_block_types' ], PHP_INT_MAX, 2 );
 
 		if ( ! wp_is_block_theme() ) {
 			add_action( 'init', [ 'Acato\Block_Editor_Templates\Admin\Admin', 'create_taxonomy_posts' ], 100 );
@@ -211,6 +212,51 @@ class Admin {
 		}
 
 		return $template;
+	}
+
+	/**
+	 * Apply the target post type's allowed blocks to its Post Type Template editor.
+	 *
+	 * A Post Type Template (the 'block-templates' post type) is edited in its own editor, so block
+	 * restrictions registered for the target post type via 'allowed_block_types_all' do not normally
+	 * apply and every block would be selectable. This re-runs that filter with a context that mimics
+	 * the target post type, so the template offers exactly the blocks the real post type allows.
+	 *
+	 * @param bool|string[]            $allowed_block_types Allowed block types, or true for all of them.
+	 * @param \WP_Block_Editor_Context $context             The current block editor context.
+	 *
+	 * @return bool|string[] The (possibly restricted) allowed block types.
+	 */
+	public static function inherit_allowed_block_types( $allowed_block_types, $context ) {
+		static $running = false;
+
+		if ( $running || ! $context instanceof \WP_Block_Editor_Context || ! $context->post instanceof WP_Post ) {
+			return $allowed_block_types;
+		}
+
+		if ( 'block-templates' !== $context->post->post_type ) {
+			return $allowed_block_types;
+		}
+
+		$target_post_type = get_post_meta( $context->post->ID, '_template_for_posttype', true );
+		if ( empty( $target_post_type ) || ! post_type_exists( $target_post_type ) ) {
+			return $allowed_block_types;
+		}
+
+		// Re-run the filter with a context that looks like the target post type, so restrictions
+		// registered for that post type apply here too. The static guard prevents infinite recursion.
+		$proxy_context = new \WP_Block_Editor_Context(
+			[
+				'name' => $context->name,
+				'post' => new \WP_Post( (object) [ 'ID' => 0, 'post_type' => $target_post_type ] ),
+			]
+		);
+
+		$running             = true;
+		$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types, $proxy_context );
+		$running             = false;
+
+		return $allowed_block_types;
 	}
 
 	/**


### PR DESCRIPTION
A Post Type Template is edited as the `block-templates` post type, so `allowed_block_types_all` restrictions registered for the **target** post type don't fire — every block is selectable even when the real post type allows only a few.

`inherit_allowed_block_types()` (hooked at `PHP_INT_MAX`) re-runs the filter with a proxy context mimicking the target post type (guarded against recursion), so the template offers exactly that post type's allowed blocks. Verified on a project with a restricted post type.