### PR TITLE
Release 1.1.0

### DIFF
--- a/block-editor-templates.php
+++ b/block-editor-templates.php
@@ -8,7 +8,7 @@
  * Plugin Name:       Block Editor Templates
  * Plugin URI:        https://www.acato.nl
  * Description:       Templates for the WordPress Block Editor.
- * Version:           1.0.7
+ * Version:           1.1.0
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            Acato
@@ -24,7 +24,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'ABET_VERSION', '1.0.7' );
+define( 'ABET_VERSION', '1.1.0' );
 
 require_once plugin_dir_path( __FILE__ ) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'class-autoloader.php';
 spl_autoload_register( [ '\Acato\Block_Editor_Templates\Autoloader', 'autoload' ] );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: block editor, gutenberg, block templates
 Requires at least: 5.0
 Tested up to: 7.0.1
 Requires PHP: 7.2
-Stable tag: 1.0.7
+Stable tag: 1.1.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 
@@ -63,6 +63,18 @@ Give the block a `{base}Placeholder` attribute (e.g. `content` → `contentPlace
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.]( https://patchstack.com/database/vdp/398f3310-d285-4489-ae3b-07b8ab344119 )
 
 == Changelog ==
+
+= 1.1.0 =
+Release Date: July 14th, 2026
+
+Feature: New posts can now be prefilled with a template's content. This is configurable per template and shown in a "Prefill new posts" column in the templates list.
+Feature: Added advanced placeholder options: a "Use content as placeholder" toggle on supported blocks, an in-editor placeholder badge, and per-attribute validation. See docs/placeholder-support.md.
+Feature: The template editor now inherits the target post type's allowed block types.
+Feature: Special pages (such as the 404 page) are now data-driven and filterable by developers.
+Feature: Added a Dutch (nl_NL) translation.
+Fix: Fixed missing content when a block template is applied to a new post.
+Fix: Fixed the 404 template lookup for classic themes.
+Fix: Guarded wp_is_block_theme() so the plugin keeps working on the declared WordPress 5.0 minimum.
 
 = 1.0.7 =
 Release Date: March 9th, 2026


### PR DESCRIPTION
Bumps the plugin to **1.1.0** and updates the changelog for a WordPress.org release.

## Version bump (kept in sync for WP.org)
- `block-editor-templates.php` `Version:` header → 1.1.0
- `ABET_VERSION` constant → 1.1.0
- `readme.txt` `Stable tag:` → 1.1.0

## Changelog (curated, user-facing) for 1.1.0
**Features**
- Prefill new posts with a template's content (configurable per template, with a "Prefill new posts" list column)
- Advanced placeholder options: "Use content as placeholder" toggle, in-editor placeholder badge, per-attribute validation (see `docs/placeholder-support.md`)
- Template editor inherits the target post type's allowed block types
- Special pages (e.g. 404) are data-driven and filterable
- Dutch (nl_NL) translation

**Fixes**
- Missing content when a block template is applied to a new post
- 404 template lookup for classic themes
- Guard `wp_is_block_theme()` so the declared WordPress 5.0 minimum keeps working

## WordPress.org diligence
- Stable tag matches the plugin Version header and `ABET_VERSION`
- Header fields verified: Requires at least 5.0, Requires PHP 7.2, Tested up to 7.0.1